### PR TITLE
Update configuration for Magics 3.2.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,13 +39,12 @@ export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
 src_dir="$(pwd)"
 mkdir ../build
 cd ../build
-# FIXME: re-enable NETCDF once NetCDF detection is fixed
+
 cmake $src_dir \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -DENABLE_PYTHON=1 \
   -DENABLE_FORTRAN=0 \
-  -DENABLE_NETCDF=0 \
-  -DENABLE_ECCODES=1
+  -DENABLE_NETCDF=1
 
 make -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   build:
     - cmake
-    - pkgconfig
+    - pkg-config
     - expat 2.2.*
     - glib
     - pango 1.40.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: da5f95b03e5e175e1886cc14dc45eab39af76bb2f0e40e2c20192b0683cd23e6
 
 build:
-  number: 2
+  number: 0
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.1" %}
+{% set version = "3.2.2" %}
 
 package:
   name: magics
@@ -7,7 +7,7 @@ package:
 source:
   fn: Magics-{{ version }}-Source.tar.gz
   url: https://software.ecmwf.int/wiki/download/attachments/3473464/Magics-{{ version }}-Source.tar.gz
-  sha256: da5f95b03e5e175e1886cc14dc45eab39af76bb2f0e40e2c20192b0683cd23e6
+  sha256: c70c6ffbb9b1b946266327e16851b9f708df185a4509066d9e193012f924334a
 
 build:
   number: 0
@@ -28,6 +28,7 @@ requirements:
     - jinja2
     - libnetcdf
     - boost
+    - libpng
   run:
     - expat 
     - pango 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,27 +18,27 @@ requirements:
   build:
     - cmake
     - pkg-config
-    - expat 2.2.*
+    - expat 
     - glib
-    - pango 1.40.*
-    - proj4 4.9.3
+    - pango
+    - proj4
     - eccodes
     - python
-    - numpy 1.8.*
+    - numpy 
     - jinja2
     - libnetcdf
-    - zlib
+    - hdf5
     - boost
   run:
-    - expat 2.2.*
-    - pango 1.40.*
-    - proj4 4.9.3
+    - expat 
+    - pango 
+    - proj4
     - eccodes
     - python
-    - numpy >=1.8
+    - numpy 
     - simplejson
     - libnetcdf
-    - zlib
+    - hdf5
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - numpy 
     - jinja2
     - libnetcdf
-    - hdf5
     - boost
   run:
     - expat 
@@ -38,7 +37,6 @@ requirements:
     - numpy 
     - simplejson
     - libnetcdf
-    - hdf5
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.34.1" %}
+{% set version = "3.2.1" %}
 
 package:
   name: magics
@@ -7,40 +7,37 @@ package:
 source:
   fn: Magics-{{ version }}-Source.tar.gz
   url: https://software.ecmwf.int/wiki/download/attachments/3473464/Magics-{{ version }}-Source.tar.gz
-  sha256: 8df27f8f262ebc32a61f8696df15a7b4a6e4203b2a8e53fe7aa13caa1c4e3fa4
+  sha256: da5f95b03e5e175e1886cc14dc45eab39af76bb2f0e40e2c20192b0683cd23e6
 
 build:
   number: 2
-  skip: True  # [win or not py27]
+  skip: True  # [win]
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
     - cmake
-    - swig
     - pkgconfig
-    - boost 1.64.*
     - expat 2.2.*
     - glib
     - pango 1.40.*
     - proj4 4.9.3
-    - python-eccodes
+    - eccodes
     - python
     - numpy 1.8.*
-    - perl 5.22.2.1
-    - perl-xml-parser
-    # ecBuild fails to find the C++ bindings: the library name is libnetcdf_c++4
-    # - netcdf-cxx4
+    - jinja2
+    - libnetcdf
+    - zlib
   run:
     - expat 2.2.*
     - pango 1.40.*
     - proj4 4.9.3
-    - python-eccodes
+    - eccodes
     - python
     - numpy >=1.8
     - simplejson
-    # ecBuild fails to find the C++ bindings: the library name is libnetcdf_c++4
-    # - netcdf-cxx4
+    - libnetcdf
+    - zlib
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - jinja2
     - libnetcdf
     - zlib
+    - boost
   run:
     - expat 2.2.*
     - pango 1.40.*


### PR DESCRIPTION
Over the last two years the dependencies of Magics have change quite a bit, and these changes are now reflected in the config/build files.
NetCDF support is enabled again.