### PR TITLE
Set MAGPLUS_HOME automatically on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -34,3 +34,15 @@ if errorlevel 1 exit 1
 
 nmake install
 if errorlevel 1 exit 1
+
+:: install activate/deactive scripts
+set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
+set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
+mkdir %ACTIVATE_DIR%
+mkdir %DEACTIVATE_DIR%
+
+copy %RECIPE_DIR%\scripts\activate.bat %ACTIVATE_DIR%\magics-activate.bat
+if errorlevel 1 exit 1
+
+copy %RECIPE_DIR%\scripts\deactivate.bat %DEACTIVATE_DIR%\magics-deactivate.bat
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7637fc02342b7a8ecf6c974486bd2dbfee37ddb64c12bef714d5079907edbf9a
 
 build:
-  number: 1013
+  number: 1014
   skip: True  # [win and vc<14]
   detect_binary_files_with_prefix: true
   features:

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -1,0 +1,6 @@
+:: Store existing env vars so we can restore them later
+@if defined MAGPLUS_HOME (
+    set "_CONDA_SET_MAGPLUS_HOME=%MAGPLUS_HOME%
+)
+
+@set "MAGPLUS_HOME=%CONDA_PREFIX%\Library\"

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,0 +1,7 @@
+:: Restore previous env vars if any
+@set "MAGPLUS_HOME="
+
+@if defined _CONDA_SET_MAGPLUS_HOME (
+    set "MAGPLUS_HOME=%_CONDA_SET_MAGPLUS_HOME%"
+    set "_CONDA_SET_MAGPLUS_HOME="
+)


### PR DESCRIPTION
Add scripts to automatically set or unset MAGPLUS_HOME when the conda environment is activated or deactivated on Windows.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.