### PR TITLE
Set MAGPLUS_HOME on Linux and MacOS

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -41,8 +41,6 @@ if errorlevel 1 exit 1
 :: install activate/deactive scripts
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
-mkdir %ACTIVATE_DIR%
-mkdir %DEACTIVATE_DIR%
 
 copy %RECIPE_DIR%\scripts\activate.bat %ACTIVATE_DIR%\magics-activate.bat
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -35,7 +35,7 @@ if errorlevel 1 exit 1
 nmake install
 if errorlevel 1 exit 1
 
-pip install --no-deps https://files.pythonhosted.org/packages/eb/e2/f415b83b1d6fd4788e0504a304bc405987bf3ba4da4bd75ea5d68491a277/Magics-1.0.3-py2.py3-none-any.whl
+pip install --no-deps https://files.pythonhosted.org/packages/c3/dd/373caa06915dd8a8ec2f344a1a2711dfb6a035e4a7ed786eb364a7715771/Magics-1.0.6-py2.py3-none-any.whl
 if errorlevel 1 exit 1
 
 :: install activate/deactive scripts

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -63,3 +63,11 @@ dump_output
 
 # Nicely terminate the ping output loop.
 kill $PING_LOOP_PID
+
+# Install activate/deactivate stripts
+ACTIVATE_DIR=$PRIFIX/etc/conda/activate.d
+DEACTIVATE_DIR=$PRIFIX/etc/conda/deactivate.d
+mkdir $ACTIVATE_DIR
+mkdir $DEACTIVATE_DIR
+cp $RECPIE_DIR/scripts/activate.sh $ACTIVATE_DIR/magics-activate.sh
+cp $RECPIE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/magics-deactivate.sh

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -59,12 +59,12 @@ make install >> $BUILD_OUTPUT 2>&1
 pip install --no-deps https://files.pythonhosted.org/packages/c3/dd/373caa06915dd8a8ec2f344a1a2711dfb6a035e4a7ed786eb364a7715771/Magics-1.0.6-py2.py3-none-any.whl >> $BUILD_OUTPUT 2>&1
 
 # Install activate/deactivate stripts
-ACTIVATE_DIR=$PRIFIX/etc/conda/activate.d
-DEACTIVATE_DIR=$PRIFIX/etc/conda/deactivate.d
+ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
+DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
 mkdir $ACTIVATE_DIR >> $BUILD_OUTPUT 2>&1
 mkdir $DEACTIVATE_DIR >> $BUILD_OUTPUT 2>&1
-cp $RECPIE_DIR/scripts/activate.sh $ACTIVATE_DIR/magics-activate.sh >> $BUILD_OUTPUT 2>&1
-cp $RECPIE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/magics-deactivate.sh >> $BUILD_OUTPUT 2>&1
+cp $RECIPE_DIR/scripts/activate.sh $ACTIVATE_DIR/magics-activate.sh >> $BUILD_OUTPUT 2>&1
+cp $RECIPE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/magics-deactivate.sh >> $BUILD_OUTPUT 2>&1
 
 # The build finished without returning an error so dump a tail of the output.
 dump_output

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -56,7 +56,7 @@ fi
 ctest --output-on-failure -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
 make install >> $BUILD_OUTPUT 2>&1
 
-pip install --no-deps https://files.pythonhosted.org/packages/eb/e2/f415b83b1d6fd4788e0504a304bc405987bf3ba4da4bd75ea5d68491a277/Magics-1.0.3-py2.py3-none-any.whl >> $BUILD_OUTPUT 2>&1
+pip install --no-deps https://files.pythonhosted.org/packages/c3/dd/373caa06915dd8a8ec2f344a1a2711dfb6a035e4a7ed786eb364a7715771/Magics-1.0.6-py2.py3-none-any.whl >> $BUILD_OUTPUT 2>&1
 
 # The build finished without returning an error so dump a tail of the output.
 dump_output

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -61,8 +61,6 @@ pip install --no-deps https://files.pythonhosted.org/packages/c3/dd/373caa06915d
 # Install activate/deactivate stripts
 ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
 DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
-mkdir $ACTIVATE_DIR >> $BUILD_OUTPUT 2>&1
-mkdir $DEACTIVATE_DIR >> $BUILD_OUTPUT 2>&1
 cp $RECIPE_DIR/scripts/activate.sh $ACTIVATE_DIR/magics-activate.sh >> $BUILD_OUTPUT 2>&1
 cp $RECIPE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/magics-deactivate.sh >> $BUILD_OUTPUT 2>&1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -58,16 +58,16 @@ make install >> $BUILD_OUTPUT 2>&1
 
 pip install --no-deps https://files.pythonhosted.org/packages/c3/dd/373caa06915dd8a8ec2f344a1a2711dfb6a035e4a7ed786eb364a7715771/Magics-1.0.6-py2.py3-none-any.whl >> $BUILD_OUTPUT 2>&1
 
+# Install activate/deactivate stripts
+ACTIVATE_DIR=$PRIFIX/etc/conda/activate.d
+DEACTIVATE_DIR=$PRIFIX/etc/conda/deactivate.d
+mkdir $ACTIVATE_DIR >> $BUILD_OUTPUT 2>&1
+mkdir $DEACTIVATE_DIR >> $BUILD_OUTPUT 2>&1
+cp $RECPIE_DIR/scripts/activate.sh $ACTIVATE_DIR/magics-activate.sh >> $BUILD_OUTPUT 2>&1
+cp $RECPIE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/magics-deactivate.sh >> $BUILD_OUTPUT 2>&1
+
 # The build finished without returning an error so dump a tail of the output.
 dump_output
 
 # Nicely terminate the ping output loop.
 kill $PING_LOOP_PID
-
-# Install activate/deactivate stripts
-ACTIVATE_DIR=$PRIFIX/etc/conda/activate.d
-DEACTIVATE_DIR=$PRIFIX/etc/conda/deactivate.d
-mkdir $ACTIVATE_DIR
-mkdir $DEACTIVATE_DIR
-cp $RECPIE_DIR/scripts/activate.sh $ACTIVATE_DIR/magics-activate.sh
-cp $RECPIE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/magics-deactivate.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,7 +86,7 @@ test:
     - conda inspect linkages -p $PREFIX magics  # [not win]
     - conda inspect objects -p $PREFIX magics  # [osx]
     - printf "%s\n" "${MAGPLUS_HOME:?MAGPLUS_HOME is not set"  # [not win]
-    - set | find "MAGPLUS_HOME"  # [win]
+    - set | grep "MAGPLUS_HOME"  # [win]
   imports:
     - Magics  # [not linux]
     - Magics.macro  # [not linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ requirements:
     - qt  # [not win]
     - zlib
   run:
+    - python
     - numpy
     - expat
     - pango  # [not win]
@@ -73,7 +74,6 @@ requirements:
 
 test:
   requires:
-    - python
     # the CDTs below are needed when building with Metview enabled
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
     - {{ cdt('mesa-dri-drivers') }}  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,6 +85,7 @@ test:
   commands:
     - conda inspect linkages -p $PREFIX magics  # [not win]
     - conda inspect objects -p $PREFIX magics  # [osx]
+    - printf "%s\n" "${MAGPLUS_HOME:?MAGPLUS_HOME is not set"  # [not win]
   imports:
     - Magics  # [not linux]
     - Magics.macro  # [not linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,6 +86,7 @@ test:
     - conda inspect linkages -p $PREFIX magics  # [not win]
     - conda inspect objects -p $PREFIX magics  # [osx]
     - printf "%s\n" "${MAGPLUS_HOME:?MAGPLUS_HOME is not set"  # [not win]
+    - set | find "MAGPLUS_HOME"  # [win]
   imports:
     - Magics  # [not linux]
     - Magics.macro  # [not linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3628063666859737948ed463de8e03300432b6f68a16e616a0c5e4c3387da5ee
 
 build:
-  number: 1000
+  number: 1001
   skip: True  # [(win and vc<14) or py<35]
   detect_binary_files_with_prefix: true
   features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3628063666859737948ed463de8e03300432b6f68a16e616a0c5e4c3387da5ee
 
 build:
-  number: 1001
+  number: 1002
   skip: True  # [(win and vc<14) or py<35]
   detect_binary_files_with_prefix: true
   features:

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Store existing env vars so we can restore them later
+if [ -z "$MAGPLUS_HOME" ]; then
+    export _CONDA_SET_MAGPLUS_HOME=$MAGPLUS_HOME
+fi
+
+export MAGPLUS_HOME=$CONDA_PREFIX

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Restore previous env vars if any
+export MAGPLUS_HOME=
+
+if [ -z "$_CONDA_SET_MAGPLUS_HOME" ]; then
+    export MAGPLUS_HOME=$_CONDA_SET_MAGPLUS_HOME
+    export _CONDA_SET_MAGPLUS_HOME=
+fi


### PR DESCRIPTION
This also adds python as a run dep - on my machine it was installing the python 3.6 version of magics-python in a python 3.7 environment.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.