### PR TITLE
Include magics-python from conda instead of pip

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -35,9 +35,6 @@ if errorlevel 1 exit 1
 nmake install
 if errorlevel 1 exit 1
 
-pip install --no-deps https://files.pythonhosted.org/packages/c3/dd/373caa06915dd8a8ec2f344a1a2711dfb6a035e4a7ed786eb364a7715771/Magics-1.0.6-py2.py3-none-any.whl
-if errorlevel 1 exit 1
-
 :: install activate/deactive scripts
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,8 +25,6 @@ fi
 ctest --output-on-failure -j $CPU_COUNT
 make install
 
-pip install --no-deps https://files.pythonhosted.org/packages/c3/dd/373caa06915dd8a8ec2f344a1a2711dfb6a035e4a7ed786eb364a7715771/Magics-1.0.6-py2.py3-none-any.whl
-
 # Install activate/deactivate stripts
 ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
 DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0002-Windows-define-PROJ_MSVC_DLL_IMPORT.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [(win and vc<14)]
   detect_binary_files_with_prefix: true
   features:
@@ -57,6 +57,7 @@ requirements:
     - jinja2
     - qt  # [not win]
     - zlib
+    - magics-python
   run:
     - python
     - numpy
@@ -71,6 +72,7 @@ requirements:
     - libiconv  # [win]
     - qt  # [not win]
     - zlib
+    - magics-python
 
 test:
   requires:


### PR DESCRIPTION
magics-python is now on conda-forge

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
