### PR TITLE
Do not export build directory with TPLs

### DIFF
--- a/recipe/0002-BUILD-do-not-export-TPL-paths-in-build-directory.patch
+++ b/recipe/0002-BUILD-do-not-export-TPL-paths-in-build-directory.patch
@@ -1,0 +1,39 @@
+From b8d1f45b5fc8de3d512f596fe14b63965b54a372 Mon Sep 17 00:00:00 2001
+From: Iain Russell <Iain.Russell@ecmwf.int>
+Date: Thu, 22 Aug 2019 13:24:07 +0100
+Subject: [PATCH] BUILD: do not export TPL paths in build directory [MAGP-1203]
+
+---
+ CMakeLists.txt | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d6a804a6..2f4b2b2a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -239,6 +239,22 @@ set( MAGICS_LIBRARIES MagPlus )
+ 
+ foreach( _tpl ${MAGICS_TPLS} )
+     string( TOUPPER ${_tpl} TPL )
++
++    if( REPLACE_TPL_ABSOLUTE_PATHS )
++        # replace TPL absolute paths with their library names
++        # this helps make Magics relocatable
++        set( _TMP "" )
++
++        foreach( _lib ${${TPL}_LIBRARIES} )
++            get_filename_component( _lib_name ${_lib} NAME_WE )
++            string( REGEX REPLACE "^lib" "" _name ${_lib_name} )
++            list( APPEND _TMP "-l${_name}" )
++        endforeach()
++
++        set( ${TPL}_LIBRARIES ${_TMP} )
++        set( _TMP "" )
++    endif()
++
+     list( APPEND MAGICS_EXTRA_DEFINITIONS ${${TPL}_DEFINITIONS}  )
+     list( APPEND MAGICS_EXTRA_INCLUDE_DIRS ${${TPL}_INCLUDE_DIRS} )
+     string(REGEX REPLACE "[ ]+$" "" ${TPL}_LIBRARIES "${${TPL}_LIBRARIES}") # strips leading whitespaces
+-- 
+2.13.7
+

--- a/recipe/0003-do-not-export-TPL-paths-in-build-directory.patch
+++ b/recipe/0003-do-not-export-TPL-paths-in-build-directory.patch
@@ -1,0 +1,26 @@
+From 46af1b43500e9607466dcf812161baa3426d9a01 Mon Sep 17 00:00:00 2001
+From: Iain Russell <Iain.Russell@ecmwf.int>
+Date: Mon, 2 Sep 2019 11:07:13 +0100
+Subject: [PATCH] BUILD: do not export TPL paths in build directory [MAGP-1203]
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2f4b2b2a..47634a8a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -250,6 +250,9 @@ foreach( _tpl ${MAGICS_TPLS} )
+             string( REGEX REPLACE "^lib" "" _name ${_lib_name} )
+             list( APPEND _TMP "-l${_name}" )
+         endforeach()
++        list(REMOVE_DUPLICATES  _TMP)
++        list(REMOVE_ITEM _TMP -ldebug)
++        list(REMOVE_ITEM _TMP -loptimized)
+ 
+         set( ${TPL}_LIBRARIES ${_TMP} )
+         set( _TMP "" )
+-- 
+2.13.7
+

--- a/recipe/0004-do-not-export-TPL-paths-in-build-directory.patch
+++ b/recipe/0004-do-not-export-TPL-paths-in-build-directory.patch
@@ -1,0 +1,37 @@
+From dfcd04153fd86f7d0cca9c51f08a51a93e234fc5 Mon Sep 17 00:00:00 2001
+From: Iain Russell <Iain.Russell@ecmwf.int>
+Date: Mon, 2 Sep 2019 12:23:59 +0100
+Subject: [PATCH] BUILD: do not export TPL paths in build directory [MAGP-1203]
+
+---
+ CMakeLists.txt | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 47634a8a..9fb5a21c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -248,7 +248,11 @@ foreach( _tpl ${MAGICS_TPLS} )
+         foreach( _lib ${${TPL}_LIBRARIES} )
+             get_filename_component( _lib_name ${_lib} NAME_WE )
+             string( REGEX REPLACE "^lib" "" _name ${_lib_name} )
+-            list( APPEND _TMP "-l${_name}" )
++            if( NOT ${_name} STREQUAL ${_lib_name} )
++              list( APPEND _TMP "-l${_name}" )
++            else()
++              list( APPEND _TMP "${_lib}" )
++          endif()
+         endforeach()
+         list(REMOVE_DUPLICATES  _TMP)
+         list(REMOVE_ITEM _TMP -ldebug)
+@@ -266,7 +270,6 @@ foreach( _tpl ${MAGICS_TPLS} )
+     ecbuild_info("${TPL}_LIBRARIES [${${TPL}_LIBRARIES}]") # add this to confirm that indeed it was cleaned up
+ endforeach()
+ 
+-
+ if( MAGICS_QT )
+   list( APPEND MAGICS_EXTRA_INCLUDE_DIRS  ${Qt5Widgets_INCLUDE_DIR} )
+   list( APPEND MAGICS_EXTRA_LIBRARIES     ${Qt5Widgets_LIBRARIES} )
+-- 
+2.13.7
+

--- a/recipe/0005-do-not-export-TPL-paths-in-build-directory.patch
+++ b/recipe/0005-do-not-export-TPL-paths-in-build-directory.patch
@@ -1,0 +1,27 @@
+From 24ebe5c814e32141363b04a9383ea16efd9de487 Mon Sep 17 00:00:00 2001
+From: Iain Russell <Iain.Russell@ecmwf.int>
+Date: Mon, 2 Sep 2019 12:49:49 +0100
+Subject: [PATCH] BUILD: do not export TPL paths in build directory [MAGP-1203]
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9fb5a21c..fab21f12 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -255,8 +255,8 @@ foreach( _tpl ${MAGICS_TPLS} )
+           endif()
+         endforeach()
+         list(REMOVE_DUPLICATES  _TMP)
+-        list(REMOVE_ITEM _TMP -ldebug)
+-        list(REMOVE_ITEM _TMP -loptimized)
++        list(REMOVE_ITEM _TMP debug)
++        list(REMOVE_ITEM _TMP optimized)
+ 
+         set( ${TPL}_LIBRARIES ${_TMP} )
+         set( _TMP "" )
+-- 
+2.13.7
+

--- a/recipe/0006-do-not-export-TPL-paths-in-build-directory.patch
+++ b/recipe/0006-do-not-export-TPL-paths-in-build-directory.patch
@@ -1,0 +1,40 @@
+From 137bda00e467252c2e193ecd8a94cb84d72c80da Mon Sep 17 00:00:00 2001
+From: Iain Russell <Iain.Russell@ecmwf.int>
+Date: Wed, 4 Sep 2019 10:06:16 +0100
+Subject: [PATCH] BUILD: do not export TPL paths in build directory [MAGP-1203]
+
+---
+ CMakeLists.txt | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fab21f12..d5c9ceee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -246,17 +246,23 @@ foreach( _tpl ${MAGICS_TPLS} )
+         set( _TMP "" )
+ 
+         foreach( _lib ${${TPL}_LIBRARIES} )
++            message(STATUS "inspecting ${_lib}")
+             get_filename_component( _lib_name ${_lib} NAME_WE )
++            message(STATUS "  _lib_name: ${_lib_name}")
+             string( REGEX REPLACE "^lib" "" _name ${_lib_name} )
++            message(STATUS "  after replace: ${_name}")
+             if( NOT ${_name} STREQUAL ${_lib_name} )
++              message(STATUS "  adding new: -l${_name}")
+               list( APPEND _TMP "-l${_name}" )
+             else()
+               list( APPEND _TMP "${_lib}" )
++              message(STATUS "  adding old: ${_lib}")
+           endif()
+         endforeach()
+         list(REMOVE_DUPLICATES  _TMP)
+         list(REMOVE_ITEM _TMP debug)
+         list(REMOVE_ITEM _TMP optimized)
++        message(STATUS "After all that: ${_TMP}")
+ 
+         set( ${TPL}_LIBRARIES ${_TMP} )
+         set( _TMP "" )
+-- 
+2.13.7
+

--- a/recipe/0007-do-not-export-TPL-paths-in-build-directory.patch
+++ b/recipe/0007-do-not-export-TPL-paths-in-build-directory.patch
@@ -1,0 +1,27 @@
+From 1782cd71992c4a51703be8afd0717aaa9a2b6804 Mon Sep 17 00:00:00 2001
+From: Iain Russell <Iain.Russell@ecmwf.int>
+Date: Wed, 4 Sep 2019 11:25:57 +0100
+Subject: [PATCH] BUILD: do not export TPL paths in build directory [MAGP-1203]
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d5c9ceee..f2f56049 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -245,7 +245,9 @@ foreach( _tpl ${MAGICS_TPLS} )
+         # this helps make Magics relocatable
+         set( _TMP "" )
+ 
+-        foreach( _lib ${${TPL}_LIBRARIES} )
++        message(STATUS "TPL libs: ${${TPL}_LIBRARIES}")
++        string(REPLACE " " ";" LIB_LIST "${${TPL}_LIBRARIES}") # lists of libs can have spaces; replace with semicolon
++        foreach( _lib ${LIB_LIST} )
+             message(STATUS "inspecting ${_lib}")
+             get_filename_component( _lib_name ${_lib} NAME_WE )
+             message(STATUS "  _lib_name: ${_lib_name}")
+-- 
+2.13.7
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,12 +7,19 @@ export PYTHON_LDFLAGS="$PREFIX/lib"
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
 
+export REPLACE_TPL_ABSOLUTE_PATHS=0
+if [[ $(uname) == Linux ]]; then
+  export REPLACE_TPL_ABSOLUTE_PATHS=1
+fi
+
+
 mkdir ../build && cd ../build
 
 cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DENABLE_FORTRAN=0 \
       -DENABLE_NETCDF=1 \
       -DENABLE_METVIEW=1 \
+      -DREPLACE_TPL_ABSOLUTE_PATHS=$REPLACE_TPL_ABSOLUTE_PATHS \
       $SRC_DIR
 
 make -j $CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 5b52fd2e10811910ad331cbaf0944127055095d33526c77a5f1782322108fcce
   patches:
     - 0001-Find-proj_6_0.lib-if-proj.lib-isn-t-found.patch
+    - 0002-BUILD-do-not-export-TPL-paths-in-build-directory.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0007-do-not-export-TPL-paths-in-build-directory.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [(win and vc<14)]
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
     - 0002-BUILD-do-not-export-TPL-paths-in-build-directory.patch
     - 0003-do-not-export-TPL-paths-in-build-directory.patch
     - 0004-do-not-export-TPL-paths-in-build-directory.patch
+    - 0005-do-not-export-TPL-paths-in-build-directory.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
     - 0003-do-not-export-TPL-paths-in-build-directory.patch
     - 0004-do-not-export-TPL-paths-in-build-directory.patch
     - 0005-do-not-export-TPL-paths-in-build-directory.patch
+    - 0006-do-not-export-TPL-paths-in-build-directory.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   patches:
     - 0001-Find-proj_6_0.lib-if-proj.lib-isn-t-found.patch
     - 0002-BUILD-do-not-export-TPL-paths-in-build-directory.patch
+    - 0003-do-not-export-TPL-paths-in-build-directory.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
     - 0004-do-not-export-TPL-paths-in-build-directory.patch
     - 0005-do-not-export-TPL-paths-in-build-directory.patch
     - 0006-do-not-export-TPL-paths-in-build-directory.patch
+    - 0007-do-not-export-TPL-paths-in-build-directory.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
     - 0001-Find-proj_6_0.lib-if-proj.lib-isn-t-found.patch
     - 0002-BUILD-do-not-export-TPL-paths-in-build-directory.patch
     - 0003-do-not-export-TPL-paths-in-build-directory.patch
+    - 0004-do-not-export-TPL-paths-in-build-directory.patch
 
 build:
   number: 2


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Testing this build because currently Metview cannot build with Magics because of TPL dependencies in the build directory.